### PR TITLE
Improve button tooltip readability when hovering with named blueprints

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 Version: 1.3.1
 Date: ????
   Features:
+  Bugfixes:
+    - Fix button tooltips not being readable when holding a named blueprint (due to text overlap).
 ---------------------------------------------------------------------------------------------------
 Version: 1.3.0
 Date: 2022-09-04

--- a/info.json
+++ b/info.json
@@ -1,0 +1,11 @@
+{
+  "name": "BlueprintTools",
+  "version": "1.3.1",
+  "title": "Blueprint Tools",
+  "author": "raiguard",
+  "contact": "https://lists.sr.ht/~raiguard/factorio-mods-discuss",
+  "homepage": "https://sr.ht/~raiguard/factorio-mods",
+  "description": "Tools for manipulating blueprints - swap wire colors, set tiles, quick-grid, configuration hotkey. Spiritual successor to Blueprint Extensions.",
+  "factorio_version": "1.1",
+  "dependencies": ["base >= 1.1.25", "flib >= 0.11.0"]
+}

--- a/locale/en/BlueprintTools.cfg
+++ b/locale/en/BlueprintTools.cfg
@@ -41,14 +41,14 @@ bpt-show-swap-wire-colors=Show "Swap wire colors" button
 bpt-consider-tiles-for-quick-grid=Consider tiles for quick-grid size
 
 [gui]
-bpt-configure-tooltip=Configure (__CONTROL__bpt-configure__)
+bpt-configure-tooltip=\nConfigure (__CONTROL__bpt-configure__)
 bpt-fill-gaps-description=If unchecked, only tiles directly below entities will be tiled. If checked, a solid platform of tiles will be added.
 bpt-fill-gaps=Fill gaps [img=info]
 bpt-margin-description=A number of tiles to add around the edges of the blueprint.
 bpt-margin=Margin [img=info]
-bpt-quick-grid-tooltip=Quick grid (__CONTROL__bpt-quick-grid__)
-bpt-set-tiles-tooltip=Set tiles (__CONTROL__bpt-set-tiles__)
-bpt-swap-wire-colors-tooltip=Swap wire colors (__CONTROL__bpt-swap-wire-colors__)
+bpt-quick-grid-tooltip=\nQuick grid (__CONTROL__bpt-quick-grid__)
+bpt-set-tiles-tooltip=\nSet tiles (__CONTROL__bpt-set-tiles__)
+bpt-swap-wire-colors-tooltip=\nSwap wire colors (__CONTROL__bpt-swap-wire-colors__)
 bpt-shortcut-give-blueprint-book-control=__CONTROL__give-blueprint-book__
 bpt-shortcut-give-blueprint-control=__CONTROL__give-blueprint__
 bpt-shortcut-give-deconstruction-planner-control=__CONTROL__give-deconstruction-planner__


### PR DESCRIPTION
The purpose of this pull request is to improve/fix button tooltip readability when hovering over buttons with a named blueprint. Unfortunately, this will make the tooltip look a bit ugly (extra blank space at top).

This is just a workaround, but I have opened up a [forum topic](https://forums.factorio.com/viewtopic.php?f=7&t=105698) to see if something could be done in vanilla game to improve the situation.

The pull request also adds back the `info.json` file (I believe it got removed by accident when the file hierarchy was flattened).